### PR TITLE
feat: add restRouteFallback for plain-permalink WordPress sites

### DIFF
--- a/src/api/astra.ts
+++ b/src/api/astra.ts
@@ -14,9 +14,9 @@ export class AstraApiClient {
 
     constructor(site: SiteConfig) {
         this._site = site;
-        // Create client with base URL pointing to wp-json root (not wp/v2)
+        const baseURL = site.restRouteFallback ? site.url : `${site.url}/wp-json`;
         this.client = axios.create({
-            baseURL: `${site.url}/wp-json`,
+            baseURL,
             auth: site.authType === 'basic' ? {
                 username: site.username,
                 password: site.auth
@@ -27,6 +27,17 @@ export class AstraApiClient {
                 ...(site.authType === 'jwt' ? { 'Authorization': `Bearer ${site.auth}` } : {})
             }
         });
+
+        // For plain-permalink sites: translate endpoint paths into ?rest_route= query params
+        if (site.restRouteFallback) {
+            this.client.interceptors.request.use(cfg => {
+                if (cfg.url && cfg.url !== '/') {
+                    cfg.params = { ...(cfg.params ?? {}), rest_route: cfg.url };
+                    cfg.url = '/';
+                }
+                return cfg;
+            });
+        }
     }
 
     get site(): SiteConfig {

--- a/src/api/base-client.ts
+++ b/src/api/base-client.ts
@@ -9,8 +9,9 @@ export class BaseApiClient {
 
   constructor(site: SiteConfig) {
     this._site = site;
+    const baseURL = site.restRouteFallback ? site.url : `${site.url}/wp-json/wp/v2`;
     this.client = axios.create({
-      baseURL: `${site.url}/wp-json/wp/v2`,
+      baseURL,
       auth: site.authType === 'basic' ? {
         username: site.username,
         password: site.auth
@@ -21,6 +22,17 @@ export class BaseApiClient {
         ...(site.authType === 'jwt' ? { 'Authorization': `Bearer ${site.auth}` } : {})
       }
     });
+
+    // For plain-permalink sites: translate endpoint paths into ?rest_route= query params
+    if (site.restRouteFallback) {
+      this.client.interceptors.request.use(cfg => {
+        if (cfg.url && cfg.url !== '/') {
+          cfg.params = { ...(cfg.params ?? {}), rest_route: '/wp/v2' + cfg.url };
+          cfg.url = '/';
+        }
+        return cfg;
+      });
+    }
 
     // Add response interceptor for better error handling
     this.client.interceptors.response.use(

--- a/src/api/health.ts
+++ b/src/api/health.ts
@@ -13,8 +13,9 @@ export class HealthApiClient {
 
     constructor(site: SiteConfig) {
         this._site = site;
+        const baseURL = site.restRouteFallback ? site.url : `${site.url}/wp-json`;
         this.client = axios.create({
-            baseURL: `${site.url}/wp-json`, // Base URL points to wp-json root
+            baseURL,
             auth: site.authType === 'basic' ? {
                 username: site.username,
                 password: site.auth
@@ -25,6 +26,17 @@ export class HealthApiClient {
                 ...(site.authType === 'jwt' ? { 'Authorization': `Bearer ${site.auth}` } : {})
             }
         });
+
+        // For plain-permalink sites: translate endpoint paths into ?rest_route= query params
+        if (site.restRouteFallback) {
+            this.client.interceptors.request.use(cfg => {
+                if (cfg.url && cfg.url !== '/') {
+                    cfg.params = { ...(cfg.params ?? {}), rest_route: cfg.url };
+                    cfg.url = '/';
+                }
+                return cfg;
+            });
+        }
     }
 
     get site(): SiteConfig {

--- a/src/api/search.ts
+++ b/src/api/search.ts
@@ -13,8 +13,9 @@ export class SearchApiClient {
 
     constructor(site: SiteConfig) {
         this._site = site;
+        const baseURL = site.restRouteFallback ? site.url : `${site.url}/wp-json`;
         this.client = axios.create({
-            baseURL: `${site.url}/wp-json`, // Base URL points to wp-json root
+            baseURL,
             auth: site.authType === 'basic' ? {
                 username: site.username,
                 password: site.auth
@@ -25,6 +26,17 @@ export class SearchApiClient {
                 ...(site.authType === 'jwt' ? { 'Authorization': `Bearer ${site.auth}` } : {})
             }
         });
+
+        // For plain-permalink sites: translate endpoint paths into ?rest_route= query params
+        if (site.restRouteFallback) {
+            this.client.interceptors.request.use(cfg => {
+                if (cfg.url && cfg.url !== '/') {
+                    cfg.params = { ...(cfg.params ?? {}), rest_route: cfg.url };
+                    cfg.url = '/';
+                }
+                return cfg;
+            });
+        }
     }
 
     get site(): SiteConfig {

--- a/src/api/shop.ts
+++ b/src/api/shop.ts
@@ -106,8 +106,9 @@ export class ShopAPI extends BaseApiClient {
     constructor(client: BaseApiClient, security: SecurityManager) {
         super(client.site);
         this.security = security;
+        const wcBaseURL = client.site.restRouteFallback ? client.site.url : `${client.site.url}/wp-json`;
         this.wcClient = axios.create({
-            baseURL: `${client.site.url}/wp-json`,
+            baseURL: wcBaseURL,
             auth: client.site.authType === 'basic' ? {
                 username: client.site.username,
                 password: client.site.auth
@@ -118,6 +119,17 @@ export class ShopAPI extends BaseApiClient {
                 ...(client.site.authType === 'jwt' ? { 'Authorization': `Bearer ${client.site.auth}` } : {})
             }
         });
+
+        // For plain-permalink sites: translate endpoint paths into ?rest_route= query params
+        if (client.site.restRouteFallback) {
+            this.wcClient.interceptors.request.use(cfg => {
+                if (cfg.url && cfg.url !== '/') {
+                    cfg.params = { ...(cfg.params ?? {}), rest_route: cfg.url };
+                    cfg.url = '/';
+                }
+                return cfg;
+            });
+        }
 
         // Add response interceptor for better error handling
         this.wcClient.interceptors.response.use(

--- a/src/config/site-config.ts
+++ b/src/config/site-config.ts
@@ -35,7 +35,8 @@ export async function loadSiteConfig(): Promise<SiteConfigurations> {
                     url: url.replace(/\/$/, ''),
                     username: site.USER,
                     auth: site.PASS,
-                    authType: (site.authType || 'basic') as 'basic' | 'jwt'
+                    authType: (site.authType || 'basic') as 'basic' | 'jwt',
+                    restRouteFallback: site.restRouteFallback
                 };
             } catch (error) {
                 throw new Error(`Invalid site URL: ${site.URL} - ${error instanceof Error ? error.message : 'Unknown error'}`);

--- a/src/handlers/tools.ts
+++ b/src/handlers/tools.ts
@@ -335,7 +335,8 @@ export async function routeToolCall(
     // Handle discovery tools
     if (toolName === 'claudeus_wp_discover_endpoints') {
         const baseUrl = clients.posts.site.url;
-        const response = await axios.get(`${baseUrl}/wp-json/`);
+        const endpoint = clients.posts.site.restRouteFallback ? '/?rest_route=/' : '/wp-json/';
+        const response = await axios.get(`${baseUrl}${endpoint}`);
         return {
             content: [{
                 type: "text",

--- a/src/tools/discovery/handlers.ts
+++ b/src/tools/discovery/handlers.ts
@@ -5,7 +5,8 @@ export async function handleDiscoveryTools(name: string, args: Record<string, un
   switch (name) {
     case 'claudeus_wp_discover_endpoints': {
       const baseUrl = client.site.url;
-      const response = await axios.get(`${baseUrl}/wp-json/`);
+      const endpoint = client.site.restRouteFallback ? '/?rest_route=/' : '/wp-json/';
+      const response = await axios.get(`${baseUrl}${endpoint}`);
       return {
         content: [{
           type: "text",

--- a/src/types.ts
+++ b/src/types.ts
@@ -187,6 +187,7 @@ export interface SiteConfig {
     username: string;
     auth: string;
     authType: 'basic' | 'jwt';
+    restRouteFallback?: boolean;
 }
 
 export interface RawSiteConfig {
@@ -194,6 +195,7 @@ export interface RawSiteConfig {
     USER: string;
     PASS: string;
     authType?: string;
+    restRouteFallback?: boolean;
 }
 
 export interface SiteConfigurations {

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -49,6 +49,7 @@ export interface SiteConfig {
     username: string;
     auth: string;
     authType: 'basic' | 'jwt';
+    restRouteFallback?: boolean;
     capabilities?: SiteCapabilities;
 }
 
@@ -57,6 +58,7 @@ export interface RawSiteConfig {
     USER: string;
     PASS: string;
     authType?: string;
+    restRouteFallback?: boolean;
     capabilities?: SiteCapabilities;
 }
 


### PR DESCRIPTION
## Summary

Some WordPress hosts (e.g. Strato shared hosting) cannot be switched to pretty permalinks because `flush_rewrite_rules()` requires a writable `.htaccess`, which the host blocks. On those sites `/wp-json/` returns **404** even though the REST API is fully functional via the `?rest_route=` query-param fallback that core WordPress always supports.

This PR adds a per-site opt-in flag `restRouteFallback` (default `false`) so the same MCP server can manage both pretty- and plain-permalink sites.

## What it does

When `restRouteFallback: true` is set on a site in `wp-sites.json`:

- The axios `baseURL` stays at the bare site root instead of `/wp-json[/wp/v2]`.
- A request interceptor rewrites every outgoing `cfg.url` into `?rest_route=<original-path>`, prefixing `/wp/v2` for the base posts/pages/users client and using an empty prefix for the health, search, shop and astra clients (their endpoints already carry their own namespace).
- The two discovery handlers use `/?rest_route=/` instead of `/wp-json/`.

When the flag is unset (default), behaviour is byte-identical to before.

## Files changed (10)

| File | Change |
|---|---|
| `src/types/config.ts`, `src/types.ts` | `restRouteFallback?: boolean` on `SiteConfig` and `RawSiteConfig` |
| `src/config/site-config.ts` | Propagate flag from raw → typed config |
| `src/api/base-client.ts` | Conditional `baseURL` + `/wp/v2`-prefixing interceptor |
| `src/api/health.ts`, `search.ts`, `shop.ts`, `astra.ts` | Conditional `baseURL` + interceptor (no namespace prefix) |
| `src/tools/discovery/handlers.ts`, `src/handlers/tools.ts` | Discovery URL fallback |

Net diff: +75 / -9.

## Verification

Tested end-to-end against three production sites on Strato whose `/wp-json/` returns 404:

| Site | `health.test_auth` | `content.get_posts` |
|---|---|---|
| rundfunk-aeterna.net | ✅ 200 | ✅ empty list |
| sonarc-ion.com | ✅ 200 | ✅ post id:61 |
| bernardandreae.de | ✅ 200 | ✅ empty list |

Regression on a pretty-permalink site (`n-solab.de`, flag unset): ✅ unchanged, post id:1 returned.

The `_links` field on returned posts confirms the interceptor is doing its job:
```
http://sonarc-ion.com/index.php?rest_route=/wp/v2/posts/61
```

## Configuration

```json
{
  "my-plain-permalink-site": {
    "URL": "https://example.com",
    "USER": "admin",
    "PASS": "xxxx xxxx xxxx",
    "restRouteFallback": true
  }
}
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)